### PR TITLE
Add German translation and docs for smart washers/dryers

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ An Oikos-inspired Lovelace card that turns a *dumb* washing machine on a smart p
 - **Live status** — a pulsing "RUNNING / IDLE" badge, an elapsed-time progress ring and a power gauge with automatic unit handling (`1950 W` is shown as `1.95 kW`; an ampere sensor is labelled "Current draw" automatically).
 - **Last cycle summary** — start time ("Today, 09:55"), duration, energy and cost, each column tappable for more-info.
 - **Quick actions** — header buttons toggle the smart plug and the finish-notification automation, and open the power history.
-- **Bilingual** — English and Russian labels out of the box; the language follows your Home Assistant profile, or set `language: en | ru` explicitly.
+- **Multilingual**: English, Russian and German labels out of the box. The language follows your Home Assistant profile, or set `language: en | ru | de` explicitly.
 - **Zero dependencies** — a single vanilla-JS file with Shadow DOM. Every entity option except `status_entity` is optional: blocks without an entity are simply hidden. Responsive via CSS container queries.
 
 ## 📦 Installation
@@ -51,7 +51,7 @@ duration_entity: input_number.wm_last_duration     # cycle duration, minutes
 energy_entity: input_number.wm_last_energy         # kWh per cycle
 cost_entity: input_number.wm_last_cost             # cost per cycle
 currency: "€"
-language: en                                       # en / ru (default: HA language)
+language: en                                       # en / ru / de (default: HA language)
 ```
 
 | Option | Required | Default | Description |
@@ -69,7 +69,7 @@ language: en                                       # en / ru (default: HA langua
 | `cost_entity` | no | — | Cost per cycle. |
 | `currency` | no | `€` | Currency symbol for the cost column. |
 | `running_states` | no | on, washing, run, spin, rinse, … | States of `status_entity` treated as "running". |
-| `language` | no | HA language | `en` or `ru`. |
+| `language` | no | HA language | `en`, `ru` or `de`. |
 
 ## 🧠 How it works with a dumb machine
 
@@ -78,7 +78,30 @@ The machine itself reports nothing — everything is derived from a smart plug w
 - a template `binary_sensor` (power above a threshold, with `delay_off` of a few minutes so inter-cycle pauses don't count as "finished") drives the status;
 - a small automation stores the cycle start into `input_datetime`, and on finish writes duration, energy and cost into `input_number` helpers which the card displays as the "Last cycle" panel.
 
-An example Home Assistant package with these sensors, helpers and automations is in [`examples/`](examples/).
+An example Home Assistant package with these sensors, helpers and automations is in [`examples/washing_machine_package.yaml`](examples/washing_machine_package.yaml).
+
+## 🔌 Using it with a smart machine
+
+If your washer or dryer already reports its own state, you don't need the plug or
+any of the helpers. Home Connect (Bosch / Siemens / Neff / Gaggenau), Miele@home,
+LG ThinQ and SmartHQ all expose an operation state entity, so `status_entity` can
+point straight at it:
+
+```yaml
+type: custom:washing-machine-card
+name: Washing machine
+status_entity: sensor.washer_operation_state
+plug_entity: switch.washer_power
+running_states: [run]
+```
+
+A dryer is the same config with a different prefix. Narrow `running_states` to the
+one state that really means "running", otherwise a paused or powered-but-idle
+appliance reads as running.
+
+[`examples/smart_appliance.yaml`](examples/smart_appliance.yaml) has the full
+version, including the progress, finish time and door values the card has no
+options for, plus notes on what stays empty and why.
 
 ## 📄 License
 

--- a/examples/smart_appliance.yaml
+++ b/examples/smart_appliance.yaml
@@ -1,0 +1,92 @@
+# =====================================================================
+# Smart washing machine / dryer, no smart plug needed
+# ---------------------------------------------------------------------
+# The card is built for a "dumb" machine on a metering plug, but it
+# works just as well with an appliance that already reports its own
+# state. Home Connect (Bosch / Siemens / Neff / Gaggenau), Miele@home,
+# LG ThinQ and SmartHQ all expose an operation state entity.
+#
+# You don't have to create anything for this. No template sensor, no
+# helpers, no automations. Point status_entity at the operation state
+# and you're done. A dryer works the same way, only the prefix changes.
+#
+#   type: custom:washing-machine-card
+#   name: Washing machine
+#   status_entity: sensor.washer_operation_state
+#   plug_entity: switch.washer_power     # header button toggles the appliance
+#   running_states: [run]                # see note (a)
+#
+#   type: custom:washing-machine-card
+#   name: Dryer
+#   status_entity: sensor.dryer_operation_state
+#   plug_entity: switch.dryer_power
+#   running_states: [run]
+#
+# The block below is the fuller version: the card plus the values it
+# has no options for. A smart appliance reports progress, finish time,
+# door and programme, so put those next to the card and the two halves
+# complement each other. Entity names follow Home Connect, adjust them
+# to your own.
+# =====================================================================
+
+type: grid
+cards:
+  - type: heading
+    heading: Washing machine
+    icon: mdi:washing-machine
+
+  - type: custom:washing-machine-card
+    name: Washing machine
+    status_entity: sensor.washer_operation_state
+    plug_entity: switch.washer_power
+    running_states: [run]
+
+  - type: tile
+    entity: sensor.washer_program_progress
+  - type: tile
+    entity: sensor.washer_program_finish_time
+  - type: tile
+    entity: sensor.washer_door
+
+  - type: entities
+    title: Programme & status
+    entities:
+      - select.washer_active_program
+      - binary_sensor.washer_remote_start
+      - switch.washer_child_lock
+
+# =====================================================================
+# Notes
+# ---------------------------------------------------------------------
+# (a) running_states
+#     The default list has "on" in it, which is meant for a plug switch.
+#     Home Connect operation states are inactive / ready / delayedstart /
+#     run / pause / finished / error, so cut the list down to just run.
+#     Otherwise pause, or an appliance that is powered but idle, reads
+#     as running. Miele uses in_use, LG uses RUNNING. Check your own
+#     values under Developer tools -> States.
+#
+# (b) "unavailable" is normal here
+#     Home Connect appliances drop every entity to unavailable when you
+#     switch them off at the mains or when they lose Wi-Fi. That's
+#     expected, not a broken integration. Everything comes back once the
+#     appliance is powered on again.
+#
+# (c) power gauge
+#     Smart appliances usually don't report wattage, so the red gauge
+#     stays empty. If you have a metering plug behind the appliance
+#     anyway, add power_entity and the gauge works next to the reported
+#     state.
+#
+# (d) "Last cycle" panel
+#     It's fed by input_datetime / input_number helpers that an
+#     automation fills on start and finish. A smart appliance doesn't
+#     give you those, so reuse the helpers and automations from
+#     washing_machine_package.yaml and trigger them off the operation
+#     state instead of the plug power.
+#
+# (e) dryer wording
+#     The running label is washer specific in English ("Washing"). The
+#     German and Russian strings read neutrally, the English one
+#     doesn't. Worth knowing until that label becomes configurable.
+# =====================================================================

--- a/washing-machine-card.js
+++ b/washing-machine-card.js
@@ -12,6 +12,8 @@
  * License: MIT
  * Version: 1.0.0
  *
+ * UI languages: en, ru, de (auto-detected from Home Assistant, or set `language:`).
+ *
  * Install / Установка:
  *   1. Copy to /config/www/washing-machine-card.js
  *   2. Add a dashboard resource / добавьте ресурс:
@@ -55,11 +57,27 @@ class WashingMachineCard extends HTMLElement {
       tip_notify: "Уведомление об окончании", tip_plug: "Розетка машины", tip_history: "История",
       locale: "ru-RU", decimal: ",",
     },
+    de: {
+      name: "Waschmaschine",
+      badge_running: "LÄUFT", badge_idle: "BEREIT", badge_nodata: "KEINE DATEN",
+      state_running: "Läuft", state_idle: "Bereit", state_nodata: "Keine Daten",
+      ring_running: "VERGANGEN", ring_idle: "BEREIT",
+      power: "Aktuelle Leistung", current: "Stromaufnahme",
+      last_cycle: "LETZTER DURCHGANG", start: "START", duration: "DAUER",
+      energy: "VERBRAUCH", cost: "KOSTEN",
+      min: "Min", kwh: "kWh", kw: "kW",
+      today: "Heute", yesterday: "Gestern",
+      tip_notify: "Benachrichtigung bei Ende", tip_plug: "Steckdose der Maschine", tip_history: "Verlauf",
+      locale: "de-DE", decimal: ",",
+    },
   };
 
   static DEFAULTS = {
     currency: "€",
-    running_states: ["стирка", "washing", "running", "run", "wash", "on", "spin", "отжим", "полоскание", "rinse"],
+    running_states: [
+      "стирка", "washing", "running", "run", "wash", "on", "spin", "отжим", "полоскание", "rinse",
+      "waschen", "läuft", "schleudern", "spülen", "trocknen",
+    ],
     power_threshold: 10,  // above this the machine counts as running (if power_entity is set)
     power_max: 2500,      // gauge maximum, in power_entity units
   };
@@ -104,7 +122,9 @@ class WashingMachineCard extends HTMLElement {
     const cfg = this._config?.language;
     if (cfg && S[cfg]) return S[cfg];
     const haLang = (this._hass?.locale?.language || this._hass?.language || "en").toLowerCase();
-    return haLang.startsWith("ru") ? S.ru : S.en;
+    // Match the full tag first ("pt-br"), then the base language ("pt"),
+    // so adding a new entry to STRINGS is all a new translation needs.
+    return S[haLang] || S[haLang.split(/[-_]/)[0]] || S.en;
   }
 
   _st(entityId) {


### PR DESCRIPTION
Hi, thanks for the card. I'm running it on a Siemens washer and dryer and it
looks great, so here's a bit back.

Two things in this PR, both additive:

### German translation

Adds a `de` entry to `STRINGS`, and replaces the hardcoded
`haLang.startsWith("ru")` check with a lookup by language tag:

```js
return S[haLang] || S[haLang.split(/[-_]/)[0]] || S.en;
```

Same behaviour as before for en and ru, but now a new translation only needs its
own entry in `STRINGS` and nothing else. Also added the German running states
next to the Russian ones.

I kept the German labels neutral on purpose. "LÄUFT" instead of something like
"wäscht", so they read correctly on a dryer as well.

### Docs for machines that aren't dumb

The card works fine with a washer or dryer that already reports its own state,
no plug, no template sensor, no helpers. `status_entity` just points at the
operation state. The README only describes the smart plug setup though, so this
wasn't obvious to me at first.

Added a short README section and `examples/smart_appliance.yaml` with a working
Home Connect config for a washer and a dryer, plus the parts that stay empty in
that setup (power gauge, Last cycle panel) and how to fill them if you want.

The one thing worth flagging: the default `running_states` list contains `on`,
which is right for a plug switch but wrong for an operation state sensor. A
Home Connect appliance that is powered but idle sits at `ready`, and one that is
paused sits at `pause`, so `on` can make it read as running. The docs tell
people to narrow the list to just `run`. I did not change the default, that
would break the plug setup the card was designed for.

### Notes

- `README_RU.md` still has the old two-language wording and no smart appliance
  section. I did not touch it because my Russian isn't good enough to write it
  properly. Happy to add the section in English if you'd rather translate it
  yourself.
- The example file is English only. Say the word and I'll add Russian comments
  in the same style as `washing_machine_package.yaml`.
- One small thing I noticed but left alone: the running label is washer specific
  in English ("Washing"). German and Russian read neutrally, English doesn't. It
  only shows up if you use the card for a dryer. Could be worth making that
  label configurable at some point, but that felt out of scope here.
