### PR TITLE
Refactor _fmtNum method for number formatting

### DIFF
--- a/washing-machine-card.js
+++ b/washing-machine-card.js
@@ -191,7 +191,9 @@ class WashingMachineCard extends HTMLElement {
   _fmtNum(value, digits = 2) {
     const n = parseFloat(value);
     if (isNaN(n)) return null;
-    return n.toFixed(digits).replace(/\.?0+$/, "").replace(".", this._t.decimal);
+    let s = n.toFixed(digits);
+    if (digits > 0) s = s.replace(/0+$/, "").replace(/\.$/, "");
+    return s.replace(".", this._t.decimal);
   }
 
   _startDate() {


### PR DESCRIPTION
This keeps the decimal-trimming behavior for energy and power values while leaving whole-number durations untouched.

This is a proposed fix for the issue reported here: https://github.com/sionetta/wm_animated_ha_card/issues/9