### PR TITLE
Add option to hide power information, reorganized Visual Editor, and cycle duration display bug fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ last_wash_entity: input_datetime.wm_last_start     # cycle start timestamp
 duration_entity: input_number.wm_last_duration     # cycle duration, minutes
 energy_entity: input_number.wm_last_energy         # kWh per cycle
 cost_entity: input_number.wm_last_cost             # cost per cycle
+hide_status_panel: true                            # Hide status panel only when idle (Default: false)
 currency: "€"
 language: en                                       # en / ru / de / fr (default: HA language)
 theme: auto                                        # auto / light / dark
@@ -81,6 +82,7 @@ theme: auto                                        # auto / light / dark
 | `cost_entity` | no | — | Cost per cycle. |
 | `currency` | no | `€` | Currency symbol for the cost column. |
 | `running_states` | no | on, washing, run, spin, rinse, … | States of `status_entity` treated as "running" (English, Russian, German and French states are recognised). |
+| `hide_status_panel` | no | false | Hide status panel only when idle. |
 | `language` | no | HA language | `en`, `ru`, `de` or `fr`. |
 | `theme` | no | `auto` | `auto` follows the Home Assistant theme, `light` and `dark` pin it. |
 

--- a/README_DE.md
+++ b/README_DE.md
@@ -60,6 +60,7 @@ last_wash_entity: input_datetime.wm_last_start     # Startzeitpunkt des Durchgan
 duration_entity: input_number.wm_last_duration     # Dauer des Durchgangs, Minuten
 energy_entity: input_number.wm_last_energy         # kWh pro Durchgang
 cost_entity: input_number.wm_last_cost             # Kosten pro Durchgang
+hide_status_panel: true                            # Statusanzeige nur ausblenden, wenn inaktiv (Standard: false)
 currency: "€"
 language: de                                       # de / en / ru / fr (Standard: HA-Sprache)
 theme: auto                                        # auto / light / dark
@@ -81,6 +82,7 @@ theme: auto                                        # auto / light / dark
 | `cost_entity` | nein | – | Kosten pro Durchgang. |
 | `currency` | nein | `€` | Währungssymbol für die Kostenspalte. |
 | `running_states` | nein | on, washing, waschen, run, schleudern, … | Zustände von `status_entity`, die als „laufend“ gelten (deutsche, englische, russische und französische Zustände werden erkannt). |
+| `hide_status_panel` | nein | false | Statusanzeige nur ausblenden, wenn inaktiv. |
 | `language` | nein | HA-Sprache | `de`, `en`, `ru` oder `fr`. |
 | `theme` | nein | `auto` | `auto` folgt dem Home-Assistant-Theme, `light` und `dark` legen es fest. |
 

--- a/README_FR.md
+++ b/README_FR.md
@@ -60,6 +60,7 @@ last_wash_entity: input_datetime.wm_last_start     # horodatage du début de cyc
 duration_entity: input_number.wm_last_duration     # durée du cycle, en minutes
 energy_entity: input_number.wm_last_energy         # kWh par cycle
 cost_entity: input_number.wm_last_cost             # coût par cycle
+hide_status_panel: true                            # Masquer le panneau de statut uniquement lorsque l'appareil est inactif (défaut : false)
 currency: "€"
 language: fr                                       # fr / en / ru / de (défaut : langue de HA)
 theme: auto                                        # auto / light / dark
@@ -81,6 +82,7 @@ theme: auto                                        # auto / light / dark
 | `cost_entity` | non | — | Coût par cycle. |
 | `currency` | non | `€` | Symbole monétaire de la colonne coût. |
 | `running_states` | non | on, washing, lavage, run, essorage, … | États de `status_entity` considérés comme « en marche » (les états français, anglais, russes et allemands sont reconnus). |
+| `hide_status_panel` | non | false | Masquer le panneau de statut uniquement lorsque l'appareil est inactif. |
 | `language` | non | langue de HA | `fr`, `en`, `ru` ou `de`. |
 | `theme` | non | `auto` | `auto` suit le thème de Home Assistant, `light` et `dark` le figent. |
 

--- a/README_RU.md
+++ b/README_RU.md
@@ -60,6 +60,7 @@ last_wash_entity: input_datetime.wm_last_start     # время старта ц�
 duration_entity: input_number.wm_last_duration     # длительность цикла, мин
 energy_entity: input_number.wm_last_energy         # кВт·ч за цикл
 cost_entity: input_number.wm_last_cost             # стоимость цикла
+hide_status_panel: true                            # Скрывать панель статуса только в режиме ожидания (По умолчанию: false)
 currency: "₾"
 language: ru                                       # ru / en / de / fr (по умолчанию — язык HA)
 theme: auto                                        # auto / light / dark
@@ -81,6 +82,7 @@ theme: auto                                        # auto / light / dark
 | `cost_entity` | нет | — | Стоимость цикла. |
 | `currency` | нет | `€` | Символ валюты для колонки стоимости. |
 | `running_states` | нет | on, washing, стирка, run, spin, … | Состояния `status_entity`, считающиеся «работает» (распознаются русские, английские, немецкие и французские). |
+| `hide_status_panel` | нет | false | Скрывать панель статуса только в режиме ожидания. |
 | `language` | нет | язык HA | `ru`, `en`, `de` или `fr`. |
 | `theme` | нет | `auto` | `auto` следует теме Home Assistant, `light` и `dark` фиксируют оформление. |
 

--- a/washing-machine-card.js
+++ b/washing-machine-card.js
@@ -123,6 +123,7 @@ class WashingMachineCard extends HTMLElement {
     ],
     power_threshold: 10,
     power_max: 2500,
+    hide_status_panel: false,
   };
 
   static normalizeType(value) {
@@ -161,27 +162,197 @@ class WashingMachineCard extends HTMLElement {
   static getConfigForm() {
     return {
       schema: [
-        { name: "appliance_type", selector: { select: { options: [
-          { value: "washer", label: "Washer" },
-          { value: "dryer", label: "Dryer / Tumbler" },
-          { value: "dishwasher", label: "Dishwasher" },
-          { value: "oven", label: "Oven" },
-          { value: "microwave", label: "Microwave" },
-        ] } } },
-        { name: "name", selector: { text: {} } },
-        { name: "status_entity", required: true, selector: { entity: {} } },
-        { name: "plug_entity", selector: { entity: { domain: ["switch", "input_boolean"] } } },
-        { name: "notify_entity", selector: { entity: {} } },
-        { name: "power_entity", selector: { entity: { domain: "sensor" } } },
-        { name: "power_threshold", selector: { number: { min: 0, mode: "box" } } },
-        { name: "power_max", selector: { number: { min: 1, mode: "box" } } },
-        { name: "last_wash_entity", selector: { entity: { domain: "input_datetime" } } },
-        { name: "duration_entity", selector: { entity: { domain: "input_number" } } },
-        { name: "energy_entity", selector: { entity: { domain: "input_number" } } },
-        { name: "cost_entity", selector: { entity: { domain: "input_number" } } },
-        { name: "currency", selector: { text: {} } },
-        { name: "language", selector: { select: { options: ["en", "ru", "de", "fr"] } } },
-        { name: "theme", selector: { select: { options: ["auto", "light", "dark"] } } },
+        // ---- Basics: always visible, no need to expand ----
+        {
+          type: "grid",
+          name: "",
+          column_min_width: "180px",
+          schema: [
+            {
+              name: "appliance_type",
+              label: "Appliance type",
+              selector: {
+                select: {
+                  mode: "dropdown",
+                  options: [
+                    { value: "washer", label: "Washer" },
+                    { value: "dryer", label: "Dryer / Tumbler" },
+                    { value: "dishwasher", label: "Dishwasher" },
+                    { value: "oven", label: "Oven" },
+                    { value: "microwave", label: "Microwave" },
+                  ],
+                },
+              },
+            },
+            { name: "name", label: "Card name", selector: { text: {} } },
+          ],
+        },
+        {
+          name: "status_entity",
+          label: "Status entity (required)",
+          required: true,
+          selector: { entity: {} },
+        },
+
+        // ---- Appearance & language ----
+        {
+          type: "expandable",
+          name: "",
+          title: "Appearance & language",
+          icon: "mdi:palette-outline",
+          schema: [
+            {
+              type: "grid",
+              name: "",
+              column_min_width: "160px",
+              schema: [
+                {
+                  name: "language",
+                  label: "Language",
+                  selector: {
+                    select: {
+                      mode: "dropdown",
+                      options: [
+                        { value: "en", label: "English" },
+                        { value: "fr", label: "Français" },
+                        { value: "de", label: "Deutsch" },
+                        { value: "ru", label: "Русский" },
+                      ],
+                    },
+                  },
+                },
+                {
+                  name: "theme",
+                  label: "Theme",
+                  selector: {
+                    select: {
+                      mode: "dropdown",
+                      options: [
+                        { value: "auto", label: "Auto (follow Home Assistant)" },
+                        { value: "light", label: "Light" },
+                        { value: "dark", label: "Dark" },
+                      ],
+                    },
+                  },
+                },
+              ],
+            },
+            {
+              name: "hide_status_panel",
+              label: "Hide status panel when idle",
+              selector: { boolean: {} },
+              default: false,
+            },
+          ],
+        },
+
+        // ---- Power monitoring ----
+        {
+          type: "expandable",
+          name: "",
+          title: "Power monitoring",
+          icon: "mdi:flash-outline",
+          schema: [
+            {
+              name: "power_entity",
+              label: "Power sensor",
+              selector: { entity: { domain: "sensor" } },
+            },
+            {
+              type: "grid",
+              name: "",
+              column_min_width: "160px",
+              schema: [
+                {
+                  name: "power_threshold",
+                  label: "Running threshold (W)",
+                  selector: { number: { min: 0, mode: "box" } },
+                },
+                {
+                  name: "power_max",
+                  label: "Gauge max (W)",
+                  selector: { number: { min: 1, mode: "box" } },
+                },
+              ],
+            },
+          ],
+        },
+
+        // ---- Controls & notifications ----
+        {
+          type: "expandable",
+          name: "",
+          title: "Controls & notifications",
+          icon: "mdi:tune-variant",
+          schema: [
+            {
+              type: "grid",
+              name: "",
+              column_min_width: "180px",
+              schema: [
+                {
+                  name: "plug_entity",
+                  label: "Plug / switch entity",
+                  selector: { entity: { domain: ["switch", "input_boolean"] } },
+                },
+                {
+                  name: "notify_entity",
+                  label: "Notification entity",
+                  selector: { entity: {} },
+                },
+              ],
+            },
+          ],
+        },
+
+        // ---- Last cycle stats ----
+        {
+          type: "expandable",
+          name: "",
+          title: "Last cycle stats",
+          icon: "mdi:history",
+          schema: [
+            {
+              name: "last_wash_entity",
+              label: "Last start time entity",
+              selector: { entity: { domain: "input_datetime" } },
+            },
+            {
+              type: "grid",
+              name: "",
+              column_min_width: "160px",
+              schema: [
+                {
+                  name: "duration_entity",
+                  label: "Duration entity",
+                  selector: { entity: { domain: "input_number" } },
+                },
+                {
+                  name: "energy_entity",
+                  label: "Energy entity",
+                  selector: { entity: { domain: "input_number" } },
+                },
+              ],
+            },
+            {
+              type: "grid",
+              name: "",
+              column_min_width: "160px",
+              schema: [
+                {
+                  name: "cost_entity",
+                  label: "Cost entity",
+                  selector: { entity: { domain: "input_number" } },
+                },
+                {
+                  name: "currency",
+                  label: "Currency symbol",
+                  selector: { text: {} },
+                },
+              ],
+            },
+          ],
+        },
       ],
     };
   }
@@ -190,6 +361,7 @@ class WashingMachineCard extends HTMLElement {
     return {
       appliance_type: "washer",
       status_entity: "binary_sensor.washing_in_progress",
+      hide_status_panel: false,
     };
   }
 
@@ -272,7 +444,9 @@ class WashingMachineCard extends HTMLElement {
   _fmtNum(value, digits = 2) {
     const n = parseFloat(value);
     if (isNaN(n)) return null;
-    return n.toFixed(digits).replace(/\.?0+$/, "").replace(".", this._t.decimal);
+    let s = n.toFixed(digits);
+    if (digits > 0) s = s.replace(/0+$/, "").replace(/\.$/, "");
+    return s.replace(".", this._t.decimal);
   }
 
   _startDate() {
@@ -1097,7 +1271,7 @@ class WashingMachineCard extends HTMLElement {
 
           <div class="hero" id="hero">${this._machineSvg()}</div>
 
-          <div class="panel status-panel">
+          <div class="panel status-panel" id="statusPanel">
             <div class="ring-box" id="ringBox">
               <svg viewBox="0 0 96 96">
                 <circle class="ring-track" cx="48" cy="48" r="39" fill="none" stroke-width="8"/>
@@ -1205,6 +1379,10 @@ class WashingMachineCard extends HTMLElement {
       ? t.state_nodata
       : running ? t.state_running : t.state_idle;
 
+    // hide status panel only when idle
+    const hideStatus = !!c.hide_status_panel && !running;
+    this._el("statusPanel").classList.toggle("hidden", hideStatus);
+
     if (c.power_entity) {
       const ps = this._st(c.power_entity);
       const p = parseFloat(ps?.state);
@@ -1301,6 +1479,7 @@ cost_entity: input_number.wm_last_cost
 currency: "€"
 language: en                                # en | ru | de | fr
 theme: auto                                 # auto | light | dark
+hide_status_panel: false                    # true hides the status panel while idle
 
 # Other appliances — same config, one line changed:
 # appliance_type: dryer        (alias: tumbler)

--- a/washing-machine-card.js
+++ b/washing-machine-card.js
@@ -162,31 +162,24 @@ class WashingMachineCard extends HTMLElement {
   static getConfigForm() {
     return {
       schema: [
-        // ---- Basics: always visible, no need to expand ----
+        // ---- Basics: always visible ----
         {
-          type: "grid",
-          name: "",
-          column_min_width: "180px",
-          schema: [
-            {
-              name: "appliance_type",
-              label: "Appliance type",
-              selector: {
-                select: {
-                  mode: "dropdown",
-                  options: [
-                    { value: "washer", label: "Washer" },
-                    { value: "dryer", label: "Dryer / Tumbler" },
-                    { value: "dishwasher", label: "Dishwasher" },
-                    { value: "oven", label: "Oven" },
-                    { value: "microwave", label: "Microwave" },
-                  ],
-                },
-              },
+          name: "appliance_type",
+          label: "Appliance type",
+          selector: {
+            select: {
+              mode: "dropdown",
+              options: [
+                { value: "washer", label: "Washer" },
+                { value: "dryer", label: "Dryer / Tumbler" },
+                { value: "dishwasher", label: "Dishwasher" },
+                { value: "oven", label: "Oven" },
+                { value: "microwave", label: "Microwave" },
+              ],
             },
-            { name: "name", label: "Card name", selector: { text: {} } },
-          ],
+          },
         },
+        { name: "name", label: "Card name", selector: { text: {} } },
         {
           name: "status_entity",
           label: "Status entity (required)",
@@ -202,40 +195,33 @@ class WashingMachineCard extends HTMLElement {
           icon: "mdi:palette-outline",
           schema: [
             {
-              type: "grid",
-              name: "",
-              column_min_width: "160px",
-              schema: [
-                {
-                  name: "language",
-                  label: "Language",
-                  selector: {
-                    select: {
-                      mode: "dropdown",
-                      options: [
-                        { value: "en", label: "English" },
-                        { value: "fr", label: "Français" },
-                        { value: "de", label: "Deutsch" },
-                        { value: "ru", label: "Русский" },
-                      ],
-                    },
-                  },
+              name: "language",
+              label: "Language",
+              selector: {
+                select: {
+                  mode: "dropdown",
+                  options: [
+                    { value: "en", label: "English" },
+                    { value: "fr", label: "Français" },
+                    { value: "de", label: "Deutsch" },
+                    { value: "ru", label: "Русский" },
+                  ],
                 },
-                {
-                  name: "theme",
-                  label: "Theme",
-                  selector: {
-                    select: {
-                      mode: "dropdown",
-                      options: [
-                        { value: "auto", label: "Auto (follow Home Assistant)" },
-                        { value: "light", label: "Light" },
-                        { value: "dark", label: "Dark" },
-                      ],
-                    },
-                  },
+              },
+            },
+            {
+              name: "theme",
+              label: "Theme",
+              selector: {
+                select: {
+                  mode: "dropdown",
+                  options: [
+                    { value: "auto", label: "Auto (follow Home Assistant)" },
+                    { value: "light", label: "Light" },
+                    { value: "dark", label: "Dark" },
+                  ],
                 },
-              ],
+              },
             },
             {
               name: "hide_status_panel",
@@ -259,21 +245,14 @@ class WashingMachineCard extends HTMLElement {
               selector: { entity: { domain: "sensor" } },
             },
             {
-              type: "grid",
-              name: "",
-              column_min_width: "160px",
-              schema: [
-                {
-                  name: "power_threshold",
-                  label: "Running threshold (W)",
-                  selector: { number: { min: 0, mode: "box" } },
-                },
-                {
-                  name: "power_max",
-                  label: "Gauge max (W)",
-                  selector: { number: { min: 1, mode: "box" } },
-                },
-              ],
+              name: "power_threshold",
+              label: "Running threshold (W)",
+              selector: { number: { min: 0, mode: "box" } },
+            },
+            {
+              name: "power_max",
+              label: "Gauge max (W)",
+              selector: { number: { min: 1, mode: "box" } },
             },
           ],
         },
@@ -286,21 +265,14 @@ class WashingMachineCard extends HTMLElement {
           icon: "mdi:tune-variant",
           schema: [
             {
-              type: "grid",
-              name: "",
-              column_min_width: "180px",
-              schema: [
-                {
-                  name: "plug_entity",
-                  label: "Plug / switch entity",
-                  selector: { entity: { domain: ["switch", "input_boolean"] } },
-                },
-                {
-                  name: "notify_entity",
-                  label: "Notification entity",
-                  selector: { entity: {} },
-                },
-              ],
+              name: "plug_entity",
+              label: "Plug / switch entity",
+              selector: { entity: { domain: ["switch", "input_boolean"] } },
+            },
+            {
+              name: "notify_entity",
+              label: "Notification entity",
+              selector: { entity: {} },
             },
           ],
         },
@@ -318,38 +290,24 @@ class WashingMachineCard extends HTMLElement {
               selector: { entity: { domain: "input_datetime" } },
             },
             {
-              type: "grid",
-              name: "",
-              column_min_width: "160px",
-              schema: [
-                {
-                  name: "duration_entity",
-                  label: "Duration entity",
-                  selector: { entity: { domain: "input_number" } },
-                },
-                {
-                  name: "energy_entity",
-                  label: "Energy entity",
-                  selector: { entity: { domain: "input_number" } },
-                },
-              ],
+              name: "duration_entity",
+              label: "Duration entity",
+              selector: { entity: { domain: "input_number" } },
             },
             {
-              type: "grid",
-              name: "",
-              column_min_width: "160px",
-              schema: [
-                {
-                  name: "cost_entity",
-                  label: "Cost entity",
-                  selector: { entity: { domain: "input_number" } },
-                },
-                {
-                  name: "currency",
-                  label: "Currency symbol",
-                  selector: { text: {} },
-                },
-              ],
+              name: "energy_entity",
+              label: "Energy entity",
+              selector: { entity: { domain: "input_number" } },
+            },
+            {
+              name: "cost_entity",
+              label: "Cost entity",
+              selector: { entity: { domain: "input_number" } },
+            },
+            {
+              name: "currency",
+              label: "Currency symbol",
+              selector: { text: {} },
             },
           ],
         },


### PR DESCRIPTION
Changes:
- Fix cycle duration is not displayed correctly when the value ends with a zero. [issue #9](https://github.com/sionetta/wm_animated_ha_card/issues/9)
- Add an option (yaml & Visual Editor) to hide power information when entity is not running

| Idle | Running |
|---|---|
| <img width="505" height="434" alt="image" src="https://github.com/user-attachments/assets/82f87a98-e514-40b9-8994-1e8da817eb5e" /> | <img width="500" height="571" alt="image" src="https://github.com/user-attachments/assets/dfb71f72-967f-4440-992a-7db8fe81f7f2" /> |

- Reorganized the visual editor with collapsible sections and dropdown selectors to improve layout and save space.
<img width="1014" height="767" alt="image" src="https://github.com/user-attachments/assets/b2c3b025-9545-4f53-aac8-6c6dcfc734f7" />

